### PR TITLE
Update to gnome-3-38 and update path to desktop file

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
+base: core20
 
 slots:
   # for GtkApplication registration
@@ -23,7 +23,7 @@ slots:
 apps:
   tali:
     command: usr/bin/tali
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     desktop: usr/share/applications/org.gnome.Tali.desktop
 
 parts:
@@ -34,7 +34,7 @@ parts:
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags --abbrev=10)
     override-build: |
-      sed -i.bak -e 's|=org.gnome.Tali$|=${SNAP}/meta/gui/org.gnome.Tali.svg|g' data/org.gnome.Tali.desktop.in
+      sed -i.bak -e 's|=org.gnome.Tali$|=${SNAP}/meta/gui/org.gnome.Tali.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Tali.desktop.in
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp ../src/data/icons/scalable/org.gnome.Tali.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
@@ -44,7 +44,3 @@ parts:
     meson-version: 0.58.1
     organize:
       snap/tali/current/usr: usr
-    build-packages:
-      - libgnome-games-support-1-dev
-    stage-packages:
-      - libgnome-games-support-1-3


### PR DESCRIPTION
## Description

* Updated the snapcraft extension from gnome-3-34 to gnome-3-38
* Updated path to desktop icon file
* remove unnecessary refrence to libgnome-games-support since it's included in gnome-3-38

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I built this locally and tested this in an impish vm, both xorg and wayland.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

